### PR TITLE
Avoid deprecation error in PHP 7.4

### DIFF
--- a/lib/PicoFeed/Client/Url.php
+++ b/lib/PicoFeed/Client/Url.php
@@ -134,7 +134,7 @@ class Url
     {
         $path = $this->getPath();
 
-        return empty($path) || $path{0}
+        return empty($path) || $path[0]
         !== '/';
     }
 


### PR DESCRIPTION
While I can't be certain, it appears to be the only instance of curly-brace string indexing in the entire library