### PR TITLE
Add youtube video description to content

### DIFF
--- a/lib/PicoFeed/Generator/YoutubeContentGenerator.php
+++ b/lib/PicoFeed/Generator/YoutubeContentGenerator.php
@@ -38,10 +38,21 @@ class YoutubeContentGenerator extends Base implements ContentGeneratorInterface
      */
     private function generateHtmlFromXml(Item $item)
     {
+        $content = '';
+
+        $description = $item->getTag('media:description');
+        if (!empty($description[0])) {
+            $content = $description[0];
+        }
+
         $videoId = $item->getTag('yt:videoId');
 
         if (! empty($videoId)) {
-            $item->setContent('<iframe width="560" height="315" src="//www.youtube.com/embed/'.$videoId[0].'" frameborder="0"></iframe>');
+            $content .= '<p>' . '<iframe width="560" height="315" src="//www.youtube.com/embed/'.$videoId[0].'" frameborder="0"></iframe>' . '</p>';
+        }
+
+        if (!empty($content)) {
+            $item->setContent($content);
             return true;
         }
 


### PR DESCRIPTION
Adds YouTube media:description to content.

With the new flag in XRay, the iframe tag can also be preserved for direct playing in readers then, if wanted of course.

This is code for a test in XRay - the rss feed is the from your rss channel, located in a new dir www.youtube.com

[youtube.rss.txt](https://github.com/aaronpk/picofeed/files/4514036/youtube.rss.txt)
(had to rename to .txt because it wouldn't upload otherwise)

```php
  public function testYouTubeFeed() {
    $url = 'http://www.youtube.com/youtube.rss';
    $response = $this->parse(['url' => $url, 'expect' => 'feed']);

    $body = $response->getContent();
    $this->assertEquals(200, $response->getStatusCode());
    $result = json_decode($body);
    $data = $result->data;
    $this->assertNotEmpty($data->items[0]->content->text);
    $this->assertContains('The just-announced ATEM Mini Pro has some incredible new features', $data->items[0]->content->text);
  }
php```