### PR TITLE
Fix php warning in PHP8.2 in getValidDate()

### DIFF
--- a/lib/PicoFeed/Parser/DateParser.php
+++ b/lib/PicoFeed/Parser/DateParser.php
@@ -97,7 +97,7 @@ class DateParser extends Base
         if ($date !== false) {
             $errors = DateTime::getLastErrors();
 
-            if ($errors['error_count'] === 0 && $errors['warning_count'] === 0) {
+            if ($errors === false || ($errors['error_count'] === 0 && $errors['warning_count'] === 0)) {
                 return $date;
             }
         }


### PR DESCRIPTION
Return status of getLastErrors has changed - see https://github.com/php/php-src/issues/9431